### PR TITLE
Revert "Bump requests from 2.28.1 to 2.31.0 in /lambdas/OpensearchAnomalyDetector"

### DIFF
--- a/lambdas/OpensearchAnomalyDetector/requirements.txt
+++ b/lambdas/OpensearchAnomalyDetector/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.26.75
 requests-aws4auth==1.1.2
-requests==2.31.0
+requests==2.28.1


### PR DESCRIPTION
Reverts aws-samples/near-realtime-aws-usage-anomaly-detection#2 because of breaking cases for requests & botocore/boto3 library dependencies on urllib3. 
Related issues : https://github.com/psf/requests/issues/6443, https://github.com/boto/botocore/issues/2926