### PR TITLE
Revert "Bump requests from 2.28.1 to 2.31.0 in /shared/python"

### DIFF
--- a/shared/python/requirements.txt
+++ b/shared/python/requirements.txt
@@ -1,2 +1,2 @@
 requests-aws4auth==1.1.2
-requests==2.31.0
+requests==2.28.1


### PR DESCRIPTION
Reverts aws-samples/near-realtime-aws-usage-anomaly-detection#1 because of breaking cases for requests & botocore/boto3 library dependencies on urllib3. 
Related issues : https://github.com/psf/requests/issues/6443, https://github.com/boto/botocore/issues/2926